### PR TITLE
Fix an error that always happens on startup

### DIFF
--- a/LaserRecolorJank/LaserRecolorJank.cs
+++ b/LaserRecolorJank/LaserRecolorJank.cs
@@ -164,7 +164,8 @@ namespace LaserRecolorJank
 						____directPoint.ForceLink(Mesh.DirectTargetPoint);
 						____actualPoint.ForceLink(Mesh.ActualTargetPoint);
 
-						var IsRight = __instance.Side == Chirality.Right;
+						var side = __instance.AssociatedTool == null ? Chirality.Right : __instance.Side;
+						var IsRight = side == Chirality.Right;
 						var sc = IsRight ? config.GetValue(RIGHT_NEAR) : config.GetValue(LEFT_NEAR);
 						var ec = IsRight ? config.GetValue(RIGHT_FAR)  : config.GetValue(LEFT_FAR);
 						var sv = IsRight ? config.GetValue(RIGHT_NEAR_VAR) : config.GetValue(LEFT_NEAR_VAR);
@@ -235,7 +236,8 @@ namespace LaserRecolorJank
         if (!config.GetValue(ENABLED)) return true;
         if (!config.GetValue(CURSOR_ENABLED)) return true;
 
-        var IsRight = __instance.Side == Chirality.Right;
+        var side = __instance.AssociatedTool == null ? Chirality.Right : __instance.Side;
+        var IsRight = side == Chirality.Right;
 
         Uri[] RightCursors =   {config.GetValue(RIGHT_CURSOR),
           config.GetValue(RIGHT_GRAB),


### PR DESCRIPTION
Pretty much every time I start Resonite the mod throws this error when it tries to get the Side of the InteractionLaser

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at FrooxEngine.InteractionLaser.get_Side()
   at LaserRecolorJank.Patch.InteractionLaserJank.Prefix(InteractionLaser __instance, SyncRef`1 ____cursorTexture, Sync`1 ____cursorTint, SyncRef`1 ____cursorRoot, SyncRef`1 ____cursorImageRoot, SyncRef`1 ____directCursorImageRoot, SyncRef`1 ____directLineMesh, Nullable`1 interactionCursor)
```

If we decompile it we can see that the Side property accesses the AssociatedTool

```
public Chirality Side => AssociatedTool.Side;
```

I have added some code that handles the case where the AssociatedTool is null, which fixes the error
